### PR TITLE
Fix stage concurrency definition

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
     }
 
     withEnv(["Environment=stage"]) {
-        stage "Deploy to ${env.Environment}", concurrency: 1
+        stage concurrency: 1, name: 'Deploy to ${env.Environment}'
         timeout(time: 10, unit: 'MINUTES') {
             input "Proceed with deploying to ${env.Environment}?"
         }
@@ -38,7 +38,7 @@ node {
     }
 
     withEnv(["Environment=prod"]) {
-        stage "Deploy to ${env.Environment}", concurrency: 1
+        stage concurrency: 1, name: 'Deploy to ${env.Environment}'
         timeout(time: 10, unit: 'MINUTES') {
             input "Proceed with deploying to ${env.Environment}?"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node {
     }
 
     withEnv(["Environment=stage"]) {
-        stage concurrency: 1, name: 'Deploy to ${env.Environment}'
+        stage concurrency: 1, name: "Deploy to ${env.Environment}"
         timeout(time: 10, unit: 'MINUTES') {
             input "Proceed with deploying to ${env.Environment}?"
         }
@@ -38,7 +38,7 @@ node {
     }
 
     withEnv(["Environment=prod"]) {
-        stage concurrency: 1, name: 'Deploy to ${env.Environment}'
+        stage concurrency: 1, name: "Deploy to ${env.Environment}"
         timeout(time: 10, unit: 'MINUTES') {
             input "Proceed with deploying to ${env.Environment}?"
         }


### PR DESCRIPTION
If you don't define concurrency before name for a stage you'll get this error (in version 2.1 of Pipeline at least) :

java.lang.IllegalArgumentException: Expected named arguments but got [{concurrency=1}, Deploy to stage]
